### PR TITLE
Add config to require compass item

### DIFF
--- a/SchanaModCompass/Mission/gui/schana_config.c
+++ b/SchanaModCompass/Mission/gui/schana_config.c
@@ -1,0 +1,36 @@
+class SchanaCompassServerSettings {
+    protected static string DIR = "$profile:SchanaModCompass";
+    protected static string PATH = DIR + "\\server-config.json";
+
+    protected bool requireCompassItemInInventory = false;
+
+    int GetRequireCompassItemInInventory() {
+        return requireCompassItemInInventory;
+    }
+
+    void Save() {
+        if (GetGame().IsServer()) {
+            if (!FileExist(DIR)) {
+                MakeDirectory(DIR);
+            }
+            JsonFileLoader<SchanaCompassServerSettings>.JsonSaveFile(PATH, this);
+        }
+    }
+
+    static SchanaCompassServerSettings Get() {
+        auto settings = new SchanaCompassServerSettings();
+        if (FileExist(PATH)) {
+            JsonFileLoader<SchanaCompassServerSettings>.JsonLoadFile(PATH, settings);
+        }
+        settings.Save();
+        return settings;
+    }
+}
+
+static ref SchanaCompassServerSettings g_SchanaCompassServerSettings;
+static SchanaCompassServerSettings GetSchanaCompassServerSettings() {
+    if (g_Game.IsServer() && !g_SchanaCompassServerSettings) {
+        g_SchanaCompassServerSettings = SchanaCompassServerSettings.Get();
+    }
+    return g_SchanaCompassServerSettings;
+}

--- a/SchanaModCompass/Mission/gui/schana_heading.c
+++ b/SchanaModCompass/Mission/gui/schana_heading.c
@@ -24,6 +24,9 @@ class SchanaHeadingMenu extends UIScriptedMenu {
     }
 
     void SchanaUpdate () {
+		if (!CanUseMenuCompass()) {
+            m_SchanaIsVisible = false;
+        }
         if (m_SchanaIsVisible && m_SchanaHeadingRootWidget != null && GetGame ().GetPlayer ()) {
             float angle = SchanaGetAngle ();
 
@@ -70,6 +73,10 @@ class SchanaHeadingMenu extends UIScriptedMenu {
     }
 
     void SchanaToggleHeading () {
+		if (!CanUseMenuCompass()) {
+            m_SchanaIsVisible = false;
+			return
+        }
         if (!m_SchanaIsVisible) {
             m_SchanaIsVisible = true;
         } else {
@@ -79,4 +86,30 @@ class SchanaHeadingMenu extends UIScriptedMenu {
             m_SchanaHeadingVisible = !m_SchanaHeadingVisible;
         }
     }
+	
+	// Check if user has compass item. If so, return true.
+	// Otherwise, it will return false and not allow player to
+	// see the compass heading UI.
+	bool CanUseMenuCompass() {
+		// If required compass is disabled in config, return always true.
+		if (!GetSchanaCompassServerSettings().GetRequireCompassItemInInventory()) return true;
+		
+		DayZPlayer player = DayZPlayer.Cast(GetGame().GetPlayer());
+		if (!player) return false;
+		
+		array<EntityAI> itemsArray = new array<EntityAI>;
+		player.GetInventory().EnumerateInventory(InventoryTraversalType.PREORDER, itemsArray);
+		
+		for (int i = 0; i < itemsArray.Count(); i++) {
+			if (itemsArray.Get(i)) { 
+				string itemType = itemsArray.Get(i).GetType();
+				itemType.ToLower();
+				if (itemType.Contains("compass")) {
+					return true;
+				}
+			}
+		}
+		
+		return false;
+	}
 }

--- a/SchanaModCompass/Mission/mission/missiongameplay.c
+++ b/SchanaModCompass/Mission/mission/missiongameplay.c
@@ -1,6 +1,18 @@
 modded class MissionGameplay extends MissionBase {
     private ref SchanaHeadingMenu m_SchanaHeadingMenu;
 
+	override void OnMissionStart() {
+		super.OnMissionStart();
+        GetRPCManager().AddRPC("SchanaModCompass", "SchanaCompassServerSettingsRPC", this, SingleplayerExecutionType.Both);
+		GetRPCManager().SendRPC("SchanaModCompass", "SchanaCompassServerSettingsRPC", new Param1<SchanaCompassServerSettings>(NULL), true, NULL);
+	}
+	
+	void SchanaCompassServerSettingsRPC(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target) {
+		Param1<SchanaCompassServerSettings> data;
+		if (!ctx.Read(data)) return;
+		g_SchanaCompassServerSettings = data.param1;
+	}
+	
     override void OnUpdate (float timeslice) {
         super.OnUpdate (timeslice);
 

--- a/SchanaModCompass/Mission/mission/missionserver.c
+++ b/SchanaModCompass/Mission/mission/missionserver.c
@@ -1,0 +1,14 @@
+modded class MissionServer extends MissionBase {
+    override void OnInit() {
+        super.OnInit();
+		GetSchanaCompassServerSettings();
+		GetRPCManager().AddRPC("SchanaModCompass", "SchanaCompassServerSettingsRPC", this, SingeplayerExecutionType.Both);
+	}
+	
+	void SchanaCompassServerSettingsRPC(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target) {
+		PlayerIdentity RequestedBy = PlayerIdentity.Cast(sender);
+		if (RequestedBy) {
+			GetRPCManager().SendRPC("SchanaModCompass", "SchanaCompassServerSettingsRPC", new Param1<SchanaCompassServerSettings>(GetSchanaCompassServerSettings()), true, RequestedBy);
+		}
+	}
+}

--- a/steam_publish.txt
+++ b/steam_publish.txt
@@ -4,7 +4,7 @@ UPDATE:
 Server owners can configure if survivors must have a compass in their inventory to allow seeing the UI. Default configuration:
 [code]
 {
-    "requireCompassItemInInventory": 1
+    "requireCompassItemInInventory": 0
 }
 [/code]
 

--- a/steam_publish.txt
+++ b/steam_publish.txt
@@ -1,5 +1,13 @@
 An Open Source DayZ mod to display a compass heading. Toggle on and off the display at the top of the screen with the press of a configurable key (default: 'H').
 
+UPDATE:
+Server owners can configure if survivors must have a compass in their inventory to allow seeing the UI. Default configuration:
+[code]
+{
+    "requireCompassItemInInventory": 1
+}
+[/code]
+
 You are free to use this mod on your monetized servers. If you repack or use the code in a Derivative Work, you [b]must[/b] include the entire contents of the NOTICE file in a readable place in accordance with the Apache License.
 
 This mod originated from the Carim DayZ project


### PR DESCRIPTION
Referring to CarimDayZ/dayz-mod-carim#20.

This is my first ever attempt to modify any kind of logic in DayZ. I am not a modder, but this looked somehow easy to do. I took a look in other mods of yours and took some ideas. Hope this isn't a problem.

This PR allows server owner to decide if a Compass is required for showing the UI to the user.

I tested in DayZ 1.12 on a local server.